### PR TITLE
Add flush to arbitrary file

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -24,7 +24,7 @@ use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
     future::IntoFuture,
     marker::PhantomData,
-    path::PathBuf,
+    path::Path,
     pin::Pin,
     sync::{
         mpsc::{channel as oneshot_channel, Sender as OneshotSender},
@@ -659,7 +659,7 @@ impl SharedBackend {
     }
 
     /// Flushes the DB to a specific file
-    pub fn flush_cache_to(&self, cache_path: PathBuf) {
+    pub fn flush_cache_to(&self, cache_path: &Path) {
         self.cache.0.flush_to(cache_path);
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -21,14 +21,10 @@ use revm::{
 };
 use rustc_hash::FxHashMap;
 use std::{
-    collections::{hash_map::Entry, HashMap, VecDeque},
-    future::IntoFuture,
-    marker::PhantomData,
-    pin::Pin,
-    sync::{
+    collections::{hash_map::Entry, HashMap, VecDeque}, future::IntoFuture, marker::PhantomData, path::PathBuf, pin::Pin, sync::{
         mpsc::{channel as oneshot_channel, Sender as OneshotSender},
         Arc,
-    },
+    }
 };
 
 /// Logged when an error is indicative that the user is trying to fork from a non-archive node.
@@ -656,6 +652,11 @@ impl SharedBackend {
     pub fn flush_cache(&self) {
         self.cache.0.flush();
     }
+
+
+    pub fn flush_cache_to(&self, cache_path: Option<PathBuf>) {
+        self.cache.0.flush_to(cache_path);
+    }
 }
 
 impl DatabaseRef for SharedBackend {
@@ -767,4 +768,5 @@ mod tests {
         let json = JsonBlockCacheDB::load(cache_path).unwrap();
         assert!(!json.db().accounts.read().is_empty());
     }
+
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -658,7 +658,7 @@ impl SharedBackend {
         self.cache.0.flush();
     }
 
-    pub fn flush_cache_to(&self, cache_path: Option<PathBuf>) {
+    pub fn flush_cache_to(&self, cache_path: PathBuf) {
         self.cache.0.flush_to(cache_path);
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -658,6 +658,7 @@ impl SharedBackend {
         self.cache.0.flush();
     }
 
+    /// Flushes the DB to a specific file
     pub fn flush_cache_to(&self, cache_path: PathBuf) {
         self.cache.0.flush_to(cache_path);
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -21,10 +21,15 @@ use revm::{
 };
 use rustc_hash::FxHashMap;
 use std::{
-    collections::{hash_map::Entry, HashMap, VecDeque}, future::IntoFuture, marker::PhantomData, path::PathBuf, pin::Pin, sync::{
+    collections::{hash_map::Entry, HashMap, VecDeque},
+    future::IntoFuture,
+    marker::PhantomData,
+    path::PathBuf,
+    pin::Pin,
+    sync::{
         mpsc::{channel as oneshot_channel, Sender as OneshotSender},
         Arc,
-    }
+    },
 };
 
 /// Logged when an error is indicative that the user is trying to fork from a non-archive node.
@@ -653,7 +658,6 @@ impl SharedBackend {
         self.cache.0.flush();
     }
 
-
     pub fn flush_cache_to(&self, cache_path: Option<PathBuf>) {
         self.cache.0.flush_to(cache_path);
     }
@@ -768,5 +772,4 @@ mod tests {
         let json = JsonBlockCacheDB::load(cache_path).unwrap();
         assert!(!json.db().accounts.read().is_empty());
     }
-
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -404,6 +404,7 @@ impl JsonBlockCacheDB {
         trace!(target: "cache", "saved json cache");
     }
 
+    /// Flushes the DB to disk
     #[instrument(level = "warn", skip_all, fields(path = ?self.cache_path))]
     pub fn flush_to(&self, cache_path: Option<PathBuf>) {
         let Some(path) = cache_path else {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -386,7 +386,6 @@ impl JsonBlockCacheDB {
     }
 
     /// Flushes the DB to a specific file
-    #[instrument(level = "warn", skip_all, fields(path = ?self.cache_path))]
     pub fn flush_to(&self, cache_path: PathBuf) {
         let path: PathBuf = cache_path;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,7 +10,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     fs,
     io::{BufWriter, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 use url::Url;
@@ -382,12 +382,12 @@ impl JsonBlockCacheDB {
     #[instrument(level = "warn", skip_all, fields(path = ?self.cache_path))]
     pub fn flush(&self) {
         let Some(path) = &self.cache_path else { return };
-        self.flush_to(path.clone());
+        self.flush_to(path.as_path());
     }
 
     /// Flushes the DB to a specific file
-    pub fn flush_to(&self, cache_path: PathBuf) {
-        let path: PathBuf = cache_path;
+    pub fn flush_to(&self, cache_path: &Path) {
+        let path: &Path = cache_path;
 
         trace!(target: "cache", "saving json cache");
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -382,35 +382,13 @@ impl JsonBlockCacheDB {
     #[instrument(level = "warn", skip_all, fields(path = ?self.cache_path))]
     pub fn flush(&self) {
         let Some(path) = &self.cache_path else { return };
-        trace!(target: "cache", "saving json cache");
-
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
-
-        let file = match fs::File::create(path) {
-            Ok(file) => file,
-            Err(e) => return warn!(target: "cache", %e, "Failed to open json cache for writing"),
-        };
-
-        let mut writer = BufWriter::new(file);
-        if let Err(e) = serde_json::to_writer(&mut writer, &self.data) {
-            return warn!(target: "cache", %e, "Failed to write to json cache");
-        }
-        if let Err(e) = writer.flush() {
-            return warn!(target: "cache", %e, "Failed to flush to json cache");
-        }
-
-        trace!(target: "cache", "saved json cache");
+        self.flush_to(path.clone());
     }
 
     /// Flushes the DB to disk
     #[instrument(level = "warn", skip_all, fields(path = ?self.cache_path))]
-    pub fn flush_to(&self, cache_path: Option<PathBuf>) {
-        let Some(path) = cache_path else {
-            trace!(target: "cache", "no cache path provided, skipping flush");
-            return;
-        };
+    pub fn flush_to(&self, cache_path: PathBuf) {
+        let path: PathBuf = cache_path;
 
         trace!(target: "cache", "saving json cache");
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -385,7 +385,7 @@ impl JsonBlockCacheDB {
         self.flush_to(path.clone());
     }
 
-    /// Flushes the DB to disk
+    /// Flushes the DB to a specific file
     #[instrument(level = "warn", skip_all, fields(path = ?self.cache_path))]
     pub fn flush_to(&self, cache_path: PathBuf) {
         let path: PathBuf = cache_path;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry-fork-db/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

In issue #6 was discussed of adding public functions to change state in the db, and because of this I think it makes sense to have a way to have a cache file without the need to set it in the `db` #11 , or in the case that we want to preserve the cache from the previous session without being altered.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added in `flush_to(cache_path)` `JsonBlockCacheDB`  implementation a function that lets you dump the db in a determined file.

