### PR TITLE
Provide helper methods for MemDb data

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -726,13 +726,13 @@ impl SharedBackend {
     }
 
     /// Returns the DB
-    pub fn data(&self) -> DatabaseResult<Arc<MemDb>> {
-        Ok(self.cache.0.db().clone())
+    pub fn data(&self) -> Arc<MemDb> {
+        self.cache.0.db().clone()
     }
 
     /// Returns the DB accounts
-    pub fn accounts(&self) -> DatabaseResult<AddressData> {
-        Ok(self.cache.0.db().accounts.read().clone())
+    pub fn accounts(&self) -> AddressData {
+        self.cache.0.db().accounts.read().clone()
     }
 
     /// Returns the DB accounts length
@@ -741,8 +741,8 @@ impl SharedBackend {
     }
 
     /// Returns the DB storage
-    pub fn storage(&self) -> DatabaseResult<StorageData> {
-        Ok(self.cache.0.db().storage.read().clone())
+    pub fn storage(&self) -> StorageData {
+        self.cache.0.db().storage.read().clone()
     }
 
     /// Returns the DB storage length
@@ -751,9 +751,10 @@ impl SharedBackend {
     }
 
     /// Returns the DB block_hashes
-    pub fn block_hashes(&self) -> DatabaseResult<BlockHashData> {
-        Ok(self.cache.0.db().block_hashes.read().clone())
+    pub fn block_hashes(&self) -> BlockHashData {
+        self.cache.0.db().block_hashes.read().clone()
     }
+
     /// Returns the DB block_hashes length
     pub fn block_hashes_len(&self) -> usize {
         self.cache.0.db().block_hashes.read().len()

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,6 @@
 //! Smart caching and deduplication of requests when using a forking provider
 use crate::{
-    cache::{BlockchainDb, FlushJsonBlockCacheDB, StorageInfo},
+    cache::{BlockchainDb, FlushJsonBlockCacheDB, MemDb, StorageInfo},
     error::{DatabaseError, DatabaseResult},
 };
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
@@ -723,6 +723,40 @@ impl SharedBackend {
     /// Flushes the DB to a specific file
     pub fn flush_cache_to(&self, cache_path: &Path) {
         self.cache.0.flush_to(cache_path);
+    }
+
+    /// Returns the DB
+    pub fn data(&self) -> DatabaseResult<Arc<MemDb>> {
+        Ok(self.cache.0.db().clone())
+    }
+
+    /// Returns the DB accounts
+    pub fn accounts(&self) -> DatabaseResult<AddressData> {
+        Ok(self.cache.0.db().accounts.read().clone())
+    }
+
+    /// Returns the DB accounts length
+    pub fn accounts_len(&self) -> usize {
+        self.cache.0.db().accounts.read().len()
+    }
+
+    /// Returns the DB storage
+    pub fn storage(&self) -> DatabaseResult<StorageData> {
+        Ok(self.cache.0.db().storage.read().clone())
+    }
+
+    /// Returns the DB storage length
+    pub fn storage_len(&self) -> usize {
+        self.cache.0.db().storage.read().len()
+    }
+
+    /// Returns the DB block_hashes
+    pub fn block_hashes(&self) -> DatabaseResult<BlockHashData> {
+        Ok(self.cache.0.db().block_hashes.read().clone())
+    }
+    /// Returns the DB block_hashes length
+    pub fn block_hashes_len(&self) -> usize {
+        self.cache.0.db().block_hashes.read().len()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry-fork-db/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Currently, I can't find an easy way to access data in the SharedBackend MemDb. Since its 'cache' field is private (which is likely appropriate), additional methods will be needed.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
