### PR TITLE
feat: GetAccountMode

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -108,9 +108,12 @@ enum BackendRequest {
     UpdateBlockHash(BlockHashData),
 }
 
+/// Serves as a marker to identify whether the RPC provider supports `eth_getAccount`
 #[derive(PartialEq, Clone)]
 enum GetAccountMode {
+    /// The provider supports `eth_getAccount`
     EthGetAccount,
+    /// It doesn't support, and we have to fetch balance, nonce, and code concurrently
     AccountCodeNonce,
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -9,7 +9,7 @@ use alloy_provider::{network::AnyNetwork, Provider};
 use alloy_rpc_types::{Account, Block, BlockId, Transaction};
 use alloy_serde::WithOtherFields;
 use alloy_transport::Transport;
-use eyre::{Report, WrapErr};
+use eyre::WrapErr;
 use futures::{
     channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     stream::Stream,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry-fork-db/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #9 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Introduces

```rust
enum GetAccountMode {
    EthGetAccount, // If the provider supports `eth_getAccount`
    AccountCodeNonce, // If it doesn't and we have to fetch all three concurrently.
}
``` 

Above enum is cached in the `BackendHandler` inside a `OnceLock` as it only needs to set exactly once i.e on the first request when we try to determine whether the provider supports `eth_getAccount` or not.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
