### PR TITLE
fix: accept generic header in meta builder

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -862,6 +862,19 @@ mod tests {
     const ENDPOINT: Option<&str> = option_env!("ETH_RPC_URL");
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_builder() {
+        let Some(endpoint) = ENDPOINT else { return };
+        let provider = get_http_provider(endpoint);
+
+        let any_rpc_block = provider
+            .get_block(BlockId::latest(), alloy_rpc_types::BlockTransactionsKind::Hashes)
+            .await
+            .unwrap()
+            .unwrap();
+        let _meta = BlockchainDbMeta::default().with_block(&any_rpc_block.inner);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn shared_backend() {
         let Some(endpoint) = ENDPOINT else { return };
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -148,7 +148,10 @@ impl BlockchainDbMeta {
     }
 
     /// Sets the [BlockEnv] of this instance using the provided [alloy_rpc_types::Block]
-    pub fn with_block<T: TransactionResponse>(mut self, block: &alloy_rpc_types::Block<T>) -> Self {
+    pub fn with_block<T: TransactionResponse, H: BlockHeader>(
+        mut self,
+        block: &alloy_rpc_types::Block<T, H>,
+    ) -> Self {
         self.block_env = BlockEnv {
             number: U256::from(block.header.number()),
             coinbase: block.header.beneficiary(),
@@ -158,7 +161,7 @@ impl BlockchainDbMeta {
             gas_limit: U256::from(block.header.gas_limit()),
             prevrandao: block.header.mix_hash(),
             blob_excess_gas_and_price: Some(BlobExcessGasAndPrice::new(
-                block.header.excess_blob_gas.unwrap_or_default(),
+                block.header.excess_blob_gas().unwrap_or_default(),
             )),
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry-fork-db/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, we only accept blocks with strict type `alloy_consensus::Header` in the `with_block` method of `BlockchainDbMeta`. This means we cannot use the builder for blocks with `AnyHeader`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Make `with_block` generic over `alloy_consensus::BlockHeader` 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
