### PR TITLE
feat: expose cache_path for JsonBlockCacheDB

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -467,8 +467,8 @@ impl JsonBlockCacheDB {
     }
 
     /// Returns the cache path.
-    pub const fn cache_path(&self) -> Option<&PathBuf> {
-        self.cache_path.as_ref()
+    pub fn cache_path(&self) -> Option<&Path> {
+        self.cache_path.as_ref().map(PathBuf::as_path)
     }
 }
 
@@ -691,7 +691,7 @@ mod tests {
             Arc::new(RwLock::new(BlockchainDbMeta::default())),
             Some(PathBuf::from("/tmp/foo")),
         );
-        assert_eq!(Some(&PathBuf::from("/tmp/foo")), cache_db.cache_path());
+        assert_eq!(Some(Path::new("/tmp/foo")), cache_db.cache_path());
 
         // unset
         let cache_db =

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -468,7 +468,7 @@ impl JsonBlockCacheDB {
 
     /// Returns the cache path.
     pub fn cache_path(&self) -> Option<&Path> {
-        self.cache_path.as_ref().map(PathBuf::as_path)
+        self.cache_path.as_deref()
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -467,7 +467,7 @@ impl JsonBlockCacheDB {
     }
 
     /// Returns the cache path.
-    pub fn cache_path(&self) -> Option<&PathBuf> {
+    pub const fn cache_path(&self) -> Option<&PathBuf> {
         self.cache_path.as_ref()
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -465,6 +465,11 @@ impl JsonBlockCacheDB {
 
         trace!(target: "cache", "saved json cache");
     }
+
+    /// Returns the cache path.
+    pub fn cache_path(&self) -> Option<&PathBuf> {
+        self.cache_path.as_ref()
+    }
 }
 
 /// The Data the [JsonBlockCacheDB] can read and flush
@@ -677,5 +682,20 @@ mod tests {
         assert_eq!(cache.data.accounts.read().len(), 1);
 
         let _s = serde_json::to_string(&cache).unwrap();
+    }
+
+    #[test]
+    fn can_return_cache_path_if_set() {
+        // set
+        let cache_db = JsonBlockCacheDB::new(
+            Arc::new(RwLock::new(BlockchainDbMeta::default())),
+            Some(PathBuf::from("/tmp/foo")),
+        );
+        assert_eq!(Some(&PathBuf::from("/tmp/foo")), cache_db.cache_path());
+
+        // unset
+        let cache_db =
+            JsonBlockCacheDB::new(Arc::new(RwLock::new(BlockchainDbMeta::default())), None);
+        assert_eq!(None, cache_db.cache_path());
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry-fork-db/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
As of now it's not possible to verify the `cache_path` set for `JsonBlockCacheDB`. See https://github.com/foundry-rs/foundry/pull/9729


## Solution

Expose `cache_path` for `JsonBlockCacheDB`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
