### PR TITLE
perf: clone for serializing

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -444,10 +444,10 @@ impl Serialize for JsonBlockCacheData {
     {
         let mut map = serializer.serialize_map(Some(4))?;
 
-        map.serialize_entry("meta", &*self.meta.read())?;
-        map.serialize_entry("accounts", &*self.data.accounts.read())?;
-        map.serialize_entry("storage", &*self.data.storage.read())?;
-        map.serialize_entry("block_hashes", &*self.data.block_hashes.read())?;
+        map.serialize_entry("meta", &self.meta.read().clone())?;
+        map.serialize_entry("accounts", &self.data.accounts.read().clone())?;
+        map.serialize_entry("storage", &self.data.storage.read().clone())?;
+        map.serialize_entry("block_hashes", &self.data.block_hashes.read().clone())?;
 
         map.end()
     }


### PR DESCRIPTION
we're holding the lock for the entire serialize call which is more expensive than cloning the data first, so we should clone so that we can drop the readlock immediately.

if this is serialized into a file directly via bufwriter this could cause issues