### PR TITLE
chore: update `CODEOWNERS` to improve visibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @danipopes @mattsse @klkvr
+* @danipopes @klkvr @mattsse @grandizzy @yash-atreya @zerosnacks @onbjerg


### PR DESCRIPTION
Updates `CODEOWNERS` to improve visibility as this is a direct dependency of Foundry