### PR TITLE
chore(deps): add 7 day dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a 7 day cooldown to Dependabot version updates. This delays PRs for newly released dependency versions until they are at least 7 days old, reducing noise and exposure to supply chain attacks.

Security updates bypass the cooldown and are unaffected.

Prompted by: zerosnacks