### PR TITLE
fix: bump revm to 38.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ futures = "0.3"
 
 parking_lot = "0.12"
 
-revm = { version = "37.0.0", features = ["std", "serde"] }
+revm = { version = "38.0.0", features = ["std", "serde"] }
 
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
revm 37.0.0 resolves to incompatible transitive deps (`revm-handler` 18.1.0 + `revm-inspector` 18.0.0), causing `error[E0308]: mismatched types` on all CI jobs that compile.

Bumping to revm 38.0.0 pulls compatible versions (`revm-handler` 18.1.0 + `revm-inspector` 19.0.0) and fixes CI.

**Note:** This is a semver-breaking change for downstream consumers since revm types are part of the public API. Should be released as `0.26.0`.

Prompted by: zerosnacks